### PR TITLE
Add directory READMEs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+This directory contains the Docker configuration and application code for the GCT SaaS API service.
+
+- **app/** - FastAPI application source code.
+- **requirements.txt** and **setup.py** - Python dependencies.
+- **sql/** - database initialization scripts.
+
+Start the API locally from the repository root:
+
+```bash
+docker-compose up api
+```
+
+The service will be available at `http://localhost:8000`.

--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -1,0 +1,11 @@
+# FastAPI Application
+
+This folder contains the implementation of the GCT SaaS API built with FastAPI.
+
+Subdirectories:
+- **api/** – versioned API routers (currently `v1`).
+- **core/** – coherence formulas and derivative calculators.
+- **models/** – dataclasses for persistence.
+- **services/** – integrations like `GrokService`.
+
+The entry point of the service is `main.py`.

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -1,0 +1,5 @@
+# SQL Setup
+
+This directory stores SQL files used to initialize the local development database.
+
+- **init.sql** – creates tables required by the API.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,7 @@
+# Source Code
+
+This folder collects the frontend components and Python modules used for analytics.
+
+- **components/** – React components for the user interface.
+- **analytics/** – Python utilities for real-time coherence calculations.
+- **backend/** – experimental backend script with advanced derivative logic.

--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -1,0 +1,5 @@
+# Analytics Modules
+
+This folder holds Python utilities used for coherence analytics.
+
+- **real_time_coherence.py** – reference implementation for derivative calculations and streaming utilities.

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,0 +1,5 @@
+# Experimental Backend
+
+This directory contains additional backend experiments, including:
+
+- **real_time_coherence.py** – an extended script exploring advanced derivative processing and streaming features.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,6 @@
+# React Components
+
+The `components` directory contains UI pieces for the GCT SaaS frontend.
+Currently it includes:
+
+- **GCTArchitecture.tsx** – interactive visualization of the system architecture. Each component can be clicked to reveal implementation notes.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# Tests
+
+Unit tests for the project live in this directory.
+Run them with `npm test` or directly via `pytest`.


### PR DESCRIPTION
## Summary
- document backend, source, and test directories with README files

## Testing
- `npm test` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687858b606388321b4055ff04d98a9c8